### PR TITLE
Update variable regexp to support dash separated vars

### DIFF
--- a/stylus-mode.el
+++ b/stylus-mode.el
@@ -9,7 +9,7 @@
 ;; Author: Vlad-Ștefan Harbuz
 ;; Inspired by: https://github.com/hlissner/pug-mode
 ;; URL: http://github.com/vladh
-;; Version: 1.0
+;; Version: 1.0.1
 ;; Keywords: stylus, css, language
 ;;
 ;;; Commentary:

--- a/stylus-mode.el
+++ b/stylus-mode.el
@@ -118,7 +118,7 @@ if the next line could be nested within this line.")
     (,"\\([.0-9]+:?\\(em\\|ex\\|px\\|mm\\|cm\\|in\\|pt\\|pc\\|deg\\|rad\\|grad\\|ms\\|s\\|Hz\\|kHz\\|rem\\|%\\)\\b\\)" 0 font-lock-constant-face)
     (,"\\b[0-9]+\\b" 0 font-lock-constant-face)
     (,"\\.\\w[a-zA-Z0-9\\-]+" 0 font-lock-type-face) ; class names
-    (,"$\\w+" 0 font-lock-variable-name-face)
+    (,"$\\(?:\\w\\|\\s_\\)+" 0 font-lock-variable-name-face)
     (,"@\\w[a-zA-Z0-9\\-]+" 0 font-lock-preprocessor-face) ; directives and backreferences
     ))
 


### PR DESCRIPTION
Current font-lock regexp for vars not support for dash separated variables.
Changed to support it.